### PR TITLE
Manifest fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR $INSTALL_PATH
 
 ADD *.gemspec $INSTALL_PATH
 ADD Gemfile* $INSTALL_PATH
+ADD lib/uds_plus_test_kit/version.rb $INSTALL_PATH/lib/uds_plus_test_kit/version.rb
 RUN gem install bundler
 # The below RUN line is commented out for development purposes, because any change to the 
 # required gems will break the dockerfile build process.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    uds_plus_test_kit (0.9.0)
+    uds_plus_test_kit (0.9.1)
       inferno_core (~> 0.4.4)
 
 GEM

--- a/lib/uds_plus_test_kit/input_resource_tests/read_manifest_ind_test.rb
+++ b/lib/uds_plus_test_kit/input_resource_tests/read_manifest_ind_test.rb
@@ -1,5 +1,4 @@
 require 'json'
-require_relative '../ext/fhir_models'
 
 module UDSPlusTestKit
     class ReadManifestIndTest < Inferno::Test

--- a/lib/uds_plus_test_kit/input_resource_tests/read_manifest_ind_test.rb
+++ b/lib/uds_plus_test_kit/input_resource_tests/read_manifest_ind_test.rb
@@ -1,0 +1,55 @@
+require 'json'
+require_relative '../ext/fhir_models'
+
+module UDSPlusTestKit
+    class ReadManifestIndTest < Inferno::Test
+        id :uds_plus_read_manifest_ind_test
+        title 'Receive UDS+ Import Manifest'
+        description %(
+            Test takes from the user either: the http location of the import manifest 
+            or the raw JSON of the import manifest itself.
+            It attempts to GET the data stored at the given location if a link is provided,
+            then validates whether a FHIR resource can be generated from the input data.
+        )
+
+        input :import_manifest,
+            title: 'Import Manifest',
+            optional: true,
+            description: %q(
+                User can input the Import manifest as: 
+                a URL link to the location of the manifest (ex: http://www.example.com/import_manifest.json) OR 
+                a JSON string that composes the manifest (ex: {manifest_contents}) 
+            )
+        
+        def manifest_scratch
+            scratch[:manifest_resources] ||= {}
+        end
+
+        def manifest_resources
+            manifest_scratch[:all] ||= []
+        end
+
+        run do
+            omit_if !import_manifest.present?, "No data provided; skipping test."
+
+            # if the input is a url, else it is a json
+            if import_manifest.strip[0] != '{'
+                assert_valid_http_uri(import_manifest, "Import manifest uri location is not a valid http uri.")
+                get import_manifest
+                assert_response_status(200)
+                assert_valid_json(request.response_body, "Data received from request is not a valid JSON")
+                manifest = request.response_body
+            else
+                assert_valid_json(import_manifest, "JSON inputted was not in a valid format")
+                manifest = import_manifest
+            end
+            
+            resource = FHIR::Json.from_json(manifest)
+            assert resource.is_a?(FHIR::Model), "Could not generate a valid resource from the input provided"    
+            
+            if resource.is_a?(FHIR::Model)
+                manifest_resources << resource
+            end
+        end
+    end
+end

--- a/lib/uds_plus_test_kit/input_resource_tests/resource_group.rb
+++ b/lib/uds_plus_test_kit/input_resource_tests/resource_group.rb
@@ -13,7 +13,7 @@ require_relative '../validate_income_test'
 require_relative '../validate_patient_test'
 require_relative '../validate_procedure_test'
 require_relative '../validate_sexual_orientation_test'
-require_relative '../manifest_tests/read_manifest_test'
+require_relative './read_manifest_ind_test'
 require_relative '../manifest_tests/validate_manifest_test'
 
 module UDSPlusTestKit
@@ -31,7 +31,7 @@ module UDSPlusTestKit
 
         run_as_group
 
-        test from: :uds_plus_read_manifest_test
+        test from: :uds_plus_read_manifest_ind_test
         test from: :uds_plus_validate_manifest_test
         test from: :uds_plus_read_coverage_test
         test from: :uds_plus_validate_coverage_test

--- a/lib/uds_plus_test_kit/manifest_tests/validate_manifest_test.rb
+++ b/lib/uds_plus_test_kit/manifest_tests/validate_manifest_test.rb
@@ -20,6 +20,8 @@ module UDSPlusTestKit
         end
 
         run do
+            omit_if manifest_resources.empty?, "No data of this type was identified."
+            
             profile_definition = "http://hl7.org/fhir/us/uds-plus/StructureDefinition/uds-plus-import-manifest"
             profile_with_version = "#{profile_definition}|#{UDS_PLUS_VERSION}"
             assert_valid_resource(resource: manifest_resources.first, profile_url: profile_with_version)

--- a/lib/uds_plus_test_kit/version.rb
+++ b/lib/uds_plus_test_kit/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module UDSPlusTestKit
-    VERSION = '0.9.0'
+    VERSION = '0.9.1'
     UDS_PLUS_VERSION = '0.3.0'
 end


### PR DESCRIPTION
PR pulling in changes as described in #4:

* Set the validate manifest test to omit_if there was no manifest resource inputted
* Create a copy of the read_manifest test (read_manifest_ind test) that is an exact copy of the original read test, but with the input set to optional, and for the test to be omitted if no input was given
* Modify the Resource test group to reference the read_manifest_ind test instead of the original read_manifest test

Also removed the 'ext/fhir_models' and bumps the version of the gem, fixes an issue with the Dockerfile that was missed earlier.
