### PR TITLE
Added IG version to Test Kit description and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@
 - [Connectathon Manager Tutorial](https://www.youtube.com/watch?v=wBHHgZrSF-k)
 - [FHIR 101 Video](https://vimeo.com/542197402/8fb80fea04)
 - [UDS+ Connectathon Page](https://confluence.hl7.org/pages/viewpage.action?pageId=161056877)
+
+## Version
+**Test Kit:** 1.0.2
+**IG:** 0.4.1

--- a/lib/uds_plus_test_kit/uds_plus_test_suite.rb
+++ b/lib/uds_plus_test_kit/uds_plus_test_suite.rb
@@ -9,7 +9,7 @@ module UDSPlusTestKit
         title 'UDS+ Test Kit'
         description %(
             The UDS+ Test Kit tests systems for their conformance to the [UDS+
-            Implementation Guide](http://fhir.drajer.com/index.html#uds-plus-home-page).
+            Implementation Guide v0.4.1](http://fhir.drajer.com/index.html#uds-plus-home-page).
             The included tests function as a rudimentary data receiver. This receiver will 
             take a provided Import Manifest, either as an HTTP location or as a raw json,
             and validate its contents. This includes validating the structure of the manifest,


### PR DESCRIPTION
# Summary
Following a meeting with users, it was requested that the IG version the kit is testing against be displayed in the README file, and somewhere on the kit's webpage. This PR adds it to those locations. 

_NOTE:_ These additions will need to be updated during future kit updates.
