### PR TITLE
display error downgrade to warning

### DIFF
--- a/lib/uds_plus_test_kit/uds_plus_test_suite.rb
+++ b/lib/uds_plus_test_kit/uds_plus_test_suite.rb
@@ -22,6 +22,10 @@ module UDSPlusTestKit
             # The home-lab-report contains validation tools for certain codes missing in the UDS+ package
             igs('fhir.hrsa.uds-plus#1.1.0', 'hl7.fhir.us.home-lab-report#1.0.0')
 
+            cli_context do
+              displayWarnings true
+            end
+
             # Messages will be excluded if the block evaluates to a truthy value
             exclude_message do |message|
                 message.message.match?(/\A\S+: \S+: URL value '.*' does not resolve/) ||


### PR DESCRIPTION
# Summary

HL7 Resource validator will throw an error for discrepancies in display text. With the old validator configuration this used to be a warning and is not worthy of an error in this use case. Here, we configure the validator to throw warnings as it had done previously.

[Link to Issue](https://github.com/inferno-framework/uds-plus-test-kit/issues/32)

# Testing Guidance
Run the test kit with/without the warning configuration + random text entered into the example display fields


